### PR TITLE
Structured import statements in outer .ipynb files and __init__.py

### DIFF
--- a/AMRL/Environment/Builder_Env.py
+++ b/AMRL/Environment/Builder_Env.py
@@ -1,7 +1,7 @@
-from Environment.Env_new import RealExpEnv
-from Environment.get_atom_coordinate import get_all_atom_coordinate_nm, get_atom_coordinate_nm_with_anchor
-from Environment.rrt import RRT
-from Environment.data_visualization import plot_atoms_and_design
+from .Env_new import RealExpEnv
+from .get_atom_coordinate import get_all_atom_coordinate_nm, get_atom_coordinate_nm_with_anchor
+from .rrt import RRT
+from .data_visualization import plot_atoms_and_design
 
 from scipy.spatial.distance import cdist as cdist
 import numpy as np
@@ -13,7 +13,7 @@ def circle(x, y, r, p = 100):
     for i in range(p):
         x_.append(x+r*np.cos(2*i*np.pi/p))
         y_.append(y+r*np.sin(2*i*np.pi/p))
-    return x_, y_ 
+    return x_, y_
 
 def assignment(start, goal):
     cost_matrix = cdist(np.array(start)[:,:2], np.array(goal)[:,:2])
@@ -76,7 +76,7 @@ class Structure_Builder(RealExpEnv):
             self.speed = speed
         if precision_lim is not None:
             self.precision_lim = precision_lim
-        
+
     def reset_large(self, design_nm,
                     align_design_mode = 'auto', align_design_params = {'atom_nm':None, 'design_nm':None}, sequence_mode = 'design',
                     left = None, right = None, top = None, bottom = None):
@@ -126,10 +126,10 @@ class Structure_Builder(RealExpEnv):
     def get_the_returns(self):
         """
         Get and set the parameters needed for defining a RL episode:
-        offset_nm, len_nm, 
+        offset_nm, len_nm,
         self.atom_chosen, self.design_chosen, self.obstacle_list,
         self.anchor_chosen,
-        self.next_destinatio_nm, self.paths 
+        self.next_destinatio_nm, self.paths
 
         Parameters
         ----------
@@ -141,9 +141,9 @@ class Structure_Builder(RealExpEnv):
                 offset value to use for the STM scan
 
         len_nm: float
-                image size for the STM scan 
+                image size for the STM scan
         """
-        
+
         for i in range(self.atoms.shape[0]):
             self.atom_chosen, self.design_chosen, self.obstacle_list = self.match_atoms_designs(i, mode = self.sequence_mode)
             if self.outside_obstacles is not None:
@@ -169,7 +169,7 @@ class Structure_Builder(RealExpEnv):
                 offset value to use for the STM scan
 
         len_nm: float
-                image size for the STM scan 
+                image size for the STM scan
         """
         left = np.min([self.anchor_chosen[0], self.atom_chosen[0],self.next_destinatio_nm[0]])-1.5
         right = np.max([self.anchor_chosen[0], self.atom_chosen[0],self.next_destinatio_nm[0]])+1.5
@@ -205,7 +205,7 @@ class Structure_Builder(RealExpEnv):
 
         Returns
         -------
-        None: None 
+        None: None
         """
         i = np.argmin(cdist(self.all_atom_absolute_nm, new_atom_position.reshape((-1,2))))
         new_atom_position = self.all_atom_absolute_nm[i,:]
@@ -215,8 +215,8 @@ class Structure_Builder(RealExpEnv):
 
     def match_atoms_designs(self, i = 0, mode = 'design'):
         """
-        Assign atoms to designs and choose the next atom to manipulate. 
-        If mode = 'design', choose the atom-design pair with the ith largest distance. 
+        Assign atoms to designs and choose the next atom to manipulate.
+        If mode = 'design', choose the atom-design pair with the ith largest distance.
         If mode = 'anchor', choose the atom-design pair with ith shortest atom-anchor distance
 
         Parameters
@@ -227,7 +227,7 @@ class Structure_Builder(RealExpEnv):
 
         Returns
         -------
-        atom_chosen, design_chosen: array_like 
+        atom_chosen, design_chosen: array_like
                 the chosen atom and design positions
         obstacle_list: list
                 list of obstacle positions. It will be used in the pathplanning algorithm
@@ -258,7 +258,7 @@ class Structure_Builder(RealExpEnv):
 
         Returns
         -------
-        next_target, : array_like 
+        next_target, : array_like
                 next target position
         min_path: list
                 list of steps in the planned path
@@ -305,7 +305,7 @@ class Structure_Builder(RealExpEnv):
 
         Returns
         -------
-        self.state: array_like 
+        self.state: array_like
         done: bool
         info: dict
         """
@@ -333,7 +333,7 @@ class Structure_Builder(RealExpEnv):
         self.state = np.concatenate((self.goal, (self.atom_absolute_nm - self.atom_start_absolute_nm)/self.goal_nm))
         done = self.dist_destination<self.stop_lim
         return self.state, done, info
-    
+
     def step(self, action):
         """
         Take a step in the environment with the given action
@@ -365,7 +365,7 @@ class Structure_Builder(RealExpEnv):
 
         next_state = np.concatenate((self.goal, (self.atom_absolute_nm -self.atom_start_absolute_nm)/self.goal_nm))
         info |= {'atom_absolute_nm':self.atom_absolute_nm, 'atom_absolute_nm_f' : self.atom_absolute_nm_f, 'atom_absolute_nm_b' : self.atom_absolute_nm_b, 'img_info' : self.img_info}
-        
+
         return next_state, None, done, info
 
     def scan_atom(self, anchor_nm = None, offset_nm = None, len_nm = None):
@@ -384,20 +384,20 @@ class Structure_Builder(RealExpEnv):
         Return
         ------
         self.atom_absolute_nm: array_like
-                atom position in STM coordinates (nm) 
+                atom position in STM coordinates (nm)
         self.atom_relative_nm: array_like
                 atom position relative to the template position in STM coordinates (nm)
         """
         if offset_nm is not None:
-            self.offset_nm = offset_nm 
+            self.offset_nm = offset_nm
         if len_nm is not None:
-            self.len_nm = len_nm 
+            self.len_nm = len_nm
         if anchor_nm is not None:
-            self.anchor_nm = anchor_nm 
+            self.anchor_nm = anchor_nm
 
         self.createc_controller.offset_nm = self.offset_nm
         self.createc_controller.im_size_nm = self.len_nm
-        
+
         img_forward, img_backward, offset_nm, len_nm = self.createc_controller.scan_image(speed= self.speed)
         if self.use_anchor:
             self.atom_absolute_nm_f, self.anchor_nm_f = get_atom_coordinate_nm_with_anchor(img_forward, offset_nm, len_nm, self.anchor_nm, self.obstacle_list)
@@ -428,7 +428,7 @@ class Structure_Builder(RealExpEnv):
         Return
         ------
         self.atom_absolute_nm: array_like
-                atom position in STM coordinates (nm) 
+                atom position in STM coordinates (nm)
         self.atom_relative_nm: array_like
                 atom position relative to the template position in STM coordinates (nm)
         """
@@ -471,17 +471,17 @@ class Structure_Builder(RealExpEnv):
         Parameters
         ----------
         atom_absolute_nm: array_like
-                atom position in STM coordinates (nm) 
-    
+                atom position in STM coordinates (nm)
+
         destination_absolute_nm: array_like
                 final target position in nm
 
         Return
-        ------ 
+        ------
         destination_absolute_nm: array_like
-                target position in STM coordinates (nm) 
+                target position in STM coordinates (nm)
         dr/self.goal_nm: array_like
-                target position relative to the initial atom position in STM coordinates (nm) 
+                target position relative to the initial atom position in STM coordinates (nm)
         """
         angle = np.arctan2((destination_absolute_nm-atom_start_absolute_nm)[1],(destination_absolute_nm-atom_start_absolute_nm)[0])
         goal_nm = min(self.goal_nm, np.linalg.norm(destination_absolute_nm-atom_start_absolute_nm))
@@ -500,14 +500,14 @@ class Structure_Builder(RealExpEnv):
         mvolt: float
                 bias in mV
         pcurrent: float
-                current setpoint in pA 
+                current setpoint in pA
 
         Return
         ------
         current: array_like
                 manipulation current trace
         d: float
-                tip movement distance 
+                tip movement distance
         """
         x_start_nm+=self.atom_absolute_nm[0]
         x_end_nm+=self.atom_absolute_nm[0]

--- a/AMRL/Environment/Env_new.py
+++ b/AMRL/Environment/Env_new.py
@@ -1,8 +1,8 @@
-from Environment.createc_control import Createc_Controller
+from .createc_control import Createc_Controller
 import numpy as np
-from Environment.get_atom_coordinate import get_atom_coordinate_nm
+from .get_atom_coordinate import get_atom_coordinate_nm
 import findiff
-from Environment.atom_jump_detection import AtomJumpDetector_conv
+from .atom_jump_detection import AtomJumpDetector_conv
 
 class RealExpEnv:
     """
@@ -11,7 +11,7 @@ class RealExpEnv:
     def __init__(self, step_nm, max_mvolt, max_pcurrent_to_mvolt_ratio, goal_nm, template, current_jump, im_size_nm, offset_nm,
                  manip_limit_nm, pixel, template_max_y, scan_mV, max_len, load_weight, pull_back_mV = None, pull_back_pA = None,
                  random_scan_rate = 0.5, correct_drift = False, bottom = True):
-        
+
         self.step_nm = step_nm
         self.max_mvolt = max_mvolt
         self.max_pcurrent_to_mvolt_ratio = max_pcurrent_to_mvolt_ratio
@@ -62,7 +62,7 @@ class RealExpEnv:
 
         Returns
         -------
-        self.state: array_like 
+        self.state: array_like
         info: dict
         """
         self.len = 0
@@ -86,15 +86,15 @@ class RealExpEnv:
         print('goal_nm:',goal_nm)
         self.atom_start_absolute_nm, self.atom_start_relative_nm = self.atom_absolute_nm, self.atom_relative_nm
         self.destination_relative_nm, self.destination_absolute_nm, self.goal = self.get_destination(self.atom_start_relative_nm, self.atom_start_absolute_nm, goal_nm)
-        
+
         self.state = np.concatenate((self.goal, (self.atom_absolute_nm - self.atom_start_absolute_nm)/self.goal_nm))
         self.dist_destination = goal_nm
 
-        info = {'start_absolute_nm':self.atom_start_absolute_nm, 'start_relative_nm':self.atom_start_relative_nm, 'goal_absolute_nm':self.destination_absolute_nm, 
-                'goal_relative_nm':self.destination_relative_nm, 'start_absolute_nm_f':self.atom_absolute_nm_f, 'start_absolute_nm_b':self.atom_absolute_nm_b, 
+        info = {'start_absolute_nm':self.atom_start_absolute_nm, 'start_relative_nm':self.atom_start_relative_nm, 'goal_absolute_nm':self.destination_absolute_nm,
+                'goal_relative_nm':self.destination_relative_nm, 'start_absolute_nm_f':self.atom_absolute_nm_f, 'start_absolute_nm_b':self.atom_absolute_nm_b,
                 'start_relative_nm_f':self.atom_relative_nm_f, 'start_relative_nm_b':self.atom_relative_nm_b}
         return self.state, info
-    
+
     def step(self, action):
         """
         Take a step in the environment with the given action
@@ -118,7 +118,7 @@ class RealExpEnv:
         done = self.len == self.max_len
         if not done:
             jump = self.detect_current_jump(current_series)
-            
+
         if done or jump:
             self.dist_destination, dist_start, dist_last = self.check_similarity()
             print('atom moves by: {:.3f} nm'.format(dist_start))
@@ -170,7 +170,7 @@ class RealExpEnv:
         #print('old potential:', old_potential, 'new potential:', new_potential)
         reward = self.default_reward_done*(dist<self.precision_lim) + self.default_reward*(dist>self.precision_lim) + new_potential - old_potential
         return reward
-    
+
     def scan_atom(self):
         """
         Take a STM scan and extract the atom position
@@ -178,7 +178,7 @@ class RealExpEnv:
         Return
         ------
         self.atom_absolute_nm: array_like
-                atom position in STM coordinates (nm) 
+                atom position in STM coordinates (nm)
         self.atom_relative_nm: array_like
                 atom position relative to the template position in STM coordinates (nm)
         """
@@ -192,7 +192,7 @@ class RealExpEnv:
         self.atom_relative_nm_b = atom_relative_nm_b
 
         self.atom_absolute_nm, self.atom_relative_nm, template_nm, self.template_wh = 0.5*(atom_absolute_nm_f+atom_absolute_nm_b), 0.5*(atom_relative_nm_f+atom_relative_nm_b), 0.5*(template_nm_f+template_nm_b), 0.5*(template_wh_b+template_wh_f)
-        
+
         if self.out_of_range(self.atom_absolute_nm, self.manip_limit_nm):
             print('Warning: atom is out of limit')
         if self.correct_drift:
@@ -211,7 +211,7 @@ class RealExpEnv:
                 self.template_nm = template_nm
         self.template_nm = template_nm
         return self.atom_absolute_nm, self.atom_relative_nm
-    
+
     def get_destination(self, atom_relative_nm, atom_absolute_nm, goal_nm):
         """
         Uniformly sample a new target that is within the self.inner_limit_nm
@@ -219,7 +219,7 @@ class RealExpEnv:
         Parameters
         ----------
         atom_absolute_nm: array_like
-                atom position in STM coordinates (nm) 
+                atom position in STM coordinates (nm)
         atom_relative_nm: array_like
                 atom position relative to the template position in STM coordinates (nm)
         goal_nm: array_like
@@ -228,11 +228,11 @@ class RealExpEnv:
         Return
         ------
         destination_relative_nm: array_like
-                target position relative to the template position in STM coordinates (nm) 
+                target position relative to the template position in STM coordinates (nm)
         destination_absolute_nm: array_like
-                target position in STM coordinates (nm) 
+                target position in STM coordinates (nm)
         dr/self.goal_nm: array_like
-                target position relative to the initial atom position in STM coordinates (nm) 
+                target position relative to the initial atom position in STM coordinates (nm)
         """
         while True:
             r = np.random.random()
@@ -243,14 +243,14 @@ class RealExpEnv:
                 break
         destination_relative_nm = atom_relative_nm + dr
         return destination_relative_nm, destination_absolute_nm, dr/self.goal_nm
-        
+
     def action_to_latman_input(self, action):
         """
         Convert action to lateral manipulation parameter input to Createc
 
         Parameters
         ----------
-            action: array_like 
+            action: array_like
 
         Return
         ------
@@ -261,7 +261,7 @@ class RealExpEnv:
         pcurrent: float
                 current setpoint in pA
         """
-        
+
         x_start_nm = action[0]*self.step_nm
         y_start_nm = action[1]*self.step_nm
         x_end_nm = action[2]*self.goal_nm
@@ -281,14 +281,14 @@ class RealExpEnv:
         mvolt: float
                 bias in mV
         pcurrent: float
-                current setpoint in pA 
+                current setpoint in pA
 
         Return
         ------
         current: array_like
                 manipulation current trace
         d: float
-                tip movement distance 
+                tip movement distance
         """
         x_start_nm+=self.atom_absolute_nm[0]
         x_end_nm+=self.atom_absolute_nm[0]
@@ -367,7 +367,7 @@ class RealExpEnv:
         else:
             print('CNN and old prediction both say no movement')
             return False
-        
+
     def check_similarity(self):
         """
         Take a STM scan and calculate the distance between the atom and the target, the start position, the previous position
@@ -383,7 +383,7 @@ class RealExpEnv:
         dist_start = np.linalg.norm(self.atom_absolute_nm - self.atom_start_absolute_nm)
         dist_last = np.linalg.norm(self.atom_absolute_nm - old_atom_absolute_nm)
         return dist_destination, dist_start, dist_last
-    
+
     def out_of_range(self, nm, limit_nm):
         """
         Check if the coordinates nm is outside of the limit_nm
@@ -414,15 +414,3 @@ class RealExpEnv:
                                                  np.mean(self.manip_limit_nm[:2])+2*np.random.random()-1,
                                                  np.mean(self.manip_limit_nm[2:])+2*np.random.random()-1,
                                                  mV, current, self.offset_nm, self.len_nm)
-
-        
-
-
-
-
-
-
-
-
-    
-    

--- a/AMRL/Environment/atom_drop.py
+++ b/AMRL/Environment/atom_drop.py
@@ -1,7 +1,7 @@
-from Environment.createc_control import Createc_Controller
+from .createc_control import Createc_Controller
 import numpy as np
-from Environment.get_atom_coordinate import get_all_atom_coordinate_nm
-from Environment.data_visualization import plot_atoms_and_design
+from .get_atom_coordinate import get_all_atom_coordinate_nm
+from .data_visualization import plot_atoms_and_design
 
 class AtomDrop:
     def __init__(self, pixel, scan_mV, speed = None):
@@ -25,7 +25,7 @@ class AtomDrop:
             self.all_atom_absolute_nm_b = np.array(sorted(self.all_atom_absolute_nm_b, key = lambda x: (x[0], x[1])))
 
             self.all_atom_absolute_nm = 0.5*(self.all_atom_absolute_nm_f+self.all_atom_absolute_nm_b)
-            
+
             if len(self.all_atom_absolute_nm_b)!=len(self.all_atom_absolute_nm_f):
                 print('length of list of atoms found in b and f different')
         except:
@@ -60,7 +60,5 @@ class AtomDrop:
     def pull_test(self):
         return pull_success
 
-    
+
     def single_test_drop(self, z_approach, position):'''
-
-

--- a/AMRL/Environment/createc_control.py
+++ b/AMRL/Environment/createc_control.py
@@ -26,12 +26,12 @@ class Createc_Controller:
             scan pixel
         scan_mV: float
             scan bias in mV
-        
+
         Returns
         -------
         None : None
         """
-        
+
         if im_size_nm is not None:
             self.im_size_nm = im_size_nm
         if offset_nm is not None:
@@ -43,11 +43,11 @@ class Createc_Controller:
         self.stm=win32com.client.Dispatch("pstmafm.stmafmrem")
         if self.stm.stmready()==1:
             print('succeed to connect')
-        else: 
+        else:
             self.stm = win32com.client.DispatchEx("pstmafm.stmafmrem")
             if self.stm.stmready()==1:
                 print('succeed to connect with DispatchEx')
-                
+
     def scan_image(self, DIR_NAME = None, BASE_NAME = None, counter = None, save = False, speed = None):
         """
         Take a STM scan in Createc
@@ -61,7 +61,7 @@ class Createc_Controller:
             image directory, name
         counter: int, optional
             image number
-            
+
         Return
         ------
         image: array_like
@@ -92,7 +92,7 @@ class Createc_Controller:
             time.sleep(2)
             scanstatus = self.stm.scanstatus
             if scanstatus!=2:
-                break  
+                break
         if save:
             if DIR_NAME and BASE_NAME and counter:
                 path = os.path.join(DIR_NAME, BASE_NAME + str(counter))
@@ -106,7 +106,7 @@ class Createc_Controller:
         x_length = 0.1*float(self.stm.getparam('Length x[A]'))
         y_length = 0.1*float(self.stm.getparam('Length y[A]'))
         return img_forward, img_backward, self.offset_nm, np.array([x_length, y_length])
-    
+
     def lat_manipulation(self,x_start_nm, y_start_nm, x_end_nm, y_end_nm, mvoltage, pcurrent, offset_nm, len_nm):
         """
         Execute lateral manipulation in Createc
@@ -119,7 +119,7 @@ class Createc_Controller:
         ------
         namedtuple (['time','x','y','current','dI_dV','topography'])
         """
-        
+
         x_start_pixel, y_start_pixel, x_end_pixel, y_end_pixel = self.nm_to_pixel(x_start_nm, y_start_nm, x_end_nm, y_end_nm, offset_nm, len_nm)
 
         print(x_start_pixel, y_start_pixel, x_end_pixel, y_end_pixel)
@@ -141,7 +141,7 @@ class Createc_Controller:
             return data
         else:
             return None
-    
+
     def get_Delta_X(self, im_size_nm):
         """
         Get the DeltaX value for a given image size
@@ -163,7 +163,7 @@ class Createc_Controller:
         Nx = float(self.stm.getparam('Num.X'))
         Delta_X = im_size_nm*10/(Nx*volt_unit*GainX*Xpiezoconst/DAC_unit)
         return int(Delta_X)
-    
+
     def get_scan_time(self):
         """
         Estimate scan time
@@ -175,7 +175,7 @@ class Createc_Controller:
         scan_time = float(self.stm.getparam('Sec/Image:'))
         scan_time = scan_time / 2 * (1 + 1 / float(self.stm.getparam('Delay Y')))
         return scan_time
-    
+
     def nm_to_pixel(self,x_start_nm, y_start_nm, x_end_nm, y_end_nm, offset_nm, len_nm):
         """
         Convert values from STM coordinates (nm) to pixel coordinates
@@ -217,9 +217,9 @@ class Createc_Controller:
             y_end_pixel = int(np.rint(y_end_pixel))
         else:
             y_end_pixel = None
-        
+
         return x_start_pixel, y_start_pixel, x_end_pixel, y_end_pixel
-    
+
     def set_xy_nm(self, nm):
         """
         set xy offset value in nm
@@ -236,7 +236,7 @@ class Createc_Controller:
         Xpiezoconst = float(self.stm.getparam("Xpiezoconst"))
         Ypiezoconst = float(self.stm.getparam("Ypiezoconst"))
         self.stm.setxyoffvolt(10*nm[0]/Xpiezoconst,10*nm[1]/Ypiezoconst)
-        
+
     def get_xy_nm(self):
         """
         get xy offset value in nm
@@ -255,7 +255,7 @@ class Createc_Controller:
         x_nm = -0.1*Xpiezoconst*volt_unit*float(self.stm.getparam('OffsetX'))*Xgain/DAC_unit
         y_nm = -0.1*Ypiezoconst*volt_unit*float(self.stm.getparam('OffsetY'))*Ygain/DAC_unit
         return np.array([x_nm, y_nm])
-    
+
     def _ramp_bias_same_pole(self, _end_bias_mV: float, _init_bias_mV: float, _speed: float):
         """
         To be called by ramp_bias_mV().
@@ -328,7 +328,7 @@ class Createc_Controller:
         ----------
         speed: float
             speed in A/s
-        
+
         Returns
         -------
         None : None
@@ -384,7 +384,7 @@ class Createc_Controller:
         x_nm, y_nm: float
             STM coordinates (nm)
         """
-        offset_nm = self.get_offset_nm() 
+        offset_nm = self.get_offset_nm()
         len_nm = self.get_len_nm()
         #print('offset nm:',offset_nm,'len nm:',len_nm)
         self.set_Z_approach(A)
@@ -429,12 +429,3 @@ class Createc_Controller:
         Delta_X = float(self.stm.getparam('Delta X [Dac]'))
         len_nm = Delta_X*Nx*volt_unit*GainX*Xpiezoconst/(10*DAC_unit)
         return len_nm
-
-
-
-
-
-                    
-        
-                
-

--- a/AMRL/__init__.py
+++ b/AMRL/__init__.py
@@ -1,0 +1,7 @@
+__version__ = '0.0.0'
+from .Environment.Env_new import RealExpEnv
+from .Environment.Builder_Env import Structure_Builder, assignment
+from .Environment.createc_control import Createc_Controller
+from .Environment.data_visualization import show_reset, show_done, show_step, plot_large_frame, plot_graph
+from .Environment.episode_memory import Episode_Memory
+from .RL.sac import sac_agent, ReplayMemory, HerReplayMemory

--- a/baseline_eval.ipynb
+++ b/baseline_eval.ipynb
@@ -22,10 +22,7 @@
     "import pdb\n",
     "from collections import deque, namedtuple\n",
     "import torch\n",
-    "from Environment.Env_new import RealExpEnv\n",
-    "from Environment.data_visualization import plot_graph, show_reset, show_done, show_step\n",
-    "from Environment.episode_memory import Episode_Memory\n",
-    "from Environment.createc_control import Createc_Controller\n",
+    "from AMRL import RealExpEnv, plot_graph, show_reset, show_done, show_step, Episode_Memory, Createc_Controller\n",
     "matplotlib.rcParams['image.cmap'] = 'gray'\n",
     "device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')\n",
     "print(device)"
@@ -339,7 +336,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -353,7 +350,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/multiple_atoms_building.ipynb
+++ b/multiple_atoms_building.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6a87634c",
    "metadata": {},
    "source": [
     "# Multiple Atom Building\n",
@@ -11,7 +10,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1ddba6e",
    "metadata": {},
    "source": [
     "### Importing modules"
@@ -19,20 +17,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "87012119",
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cpu\n"
+     ]
+    }
+   ],
    "source": [
     "from matplotlib import pyplot as plt\n",
     "import numpy as np\n",
-    "from Environment.Builder_Env import Structure_Builder, assignment\n",
-    "from RL.sac import sac_agent\n",
     "import matplotlib\n",
     "import torch\n",
-    "from Environment.data_visualization import show_reset, show_done, show_step, plot_large_frame\n",
-    "from Environment.episode_memory import Episode_Memory\n",
-    "from Environment.createc_control import Createc_Controller\n",
+    "from AMRL import show_reset, show_done, show_step, plot_large_frame\n",
+    "from AMRL import Structure_Builder, assignment, Episode_Memory, Createc_Controller, sac_agent\n",
     "import os\n",
     "matplotlib.rcParams['image.cmap'] = 'gray'\n",
     "device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')\n",
@@ -41,7 +43,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee51be64",
    "metadata": {},
    "source": [
     "### Define RL_operation function\n",
@@ -50,8 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "6270158a",
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f31e662f",
    "metadata": {},
    "source": [
     "### Load a trained RL agent and create a Episode_Memory object"
@@ -135,10 +134,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "8d32fbce",
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'C:/LocalUserData/User-data/phys-asp-lab/auto_manipulation/training_Ag_retrain/_critic_2640.pth'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/mm/95xps4kj035cyly7yx9l_0p40000gn/T/ipykernel_35329/3235104428.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      6\u001b[0m                  gamma=0.9, tau=0.005, alpha=1)\n\u001b[1;32m      7\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 8\u001b[0;31m \u001b[0magent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcritic\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload_state_dict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtorch\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}/_critic_{}.pth'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mweight_folder_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mepisode\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      9\u001b[0m \u001b[0magent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpolicy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload_state_dict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtorch\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}/_policy_{}.pth'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mweight_folder_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mepisode\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[0magent\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malpha\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtorch\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}/_alpha_{}.pth'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mweight_folder_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mepisode\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/torch/serialization.py\u001b[0m in \u001b[0;36mload\u001b[0;34m(f, map_location, pickle_module, **pickle_load_args)\u001b[0m\n\u001b[1;32m    592\u001b[0m         \u001b[0mpickle_load_args\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'encoding'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'utf-8'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    593\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 594\u001b[0;31m     \u001b[0;32mwith\u001b[0m \u001b[0m_open_file_like\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'rb'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mopened_file\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    595\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0m_is_zipfile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mopened_file\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    596\u001b[0m             \u001b[0;31m# The zipfile reader is going to advance the current file position.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/torch/serialization.py\u001b[0m in \u001b[0;36m_open_file_like\u001b[0;34m(name_or_buffer, mode)\u001b[0m\n\u001b[1;32m    228\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0m_open_file_like\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname_or_buffer\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0m_is_path\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname_or_buffer\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 230\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0m_open_file\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname_or_buffer\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    231\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    232\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;34m'w'\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/torch/serialization.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, name, mode)\u001b[0m\n\u001b[1;32m    209\u001b[0m \u001b[0;32mclass\u001b[0m \u001b[0m_open_file\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_opener\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    210\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 211\u001b[0;31m         \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_open_file\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    212\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    213\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__exit__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'C:/LocalUserData/User-data/phys-asp-lab/auto_manipulation/training_Ag_retrain/_critic_2640.pth'"
+     ]
+    }
+   ],
    "source": [
     "#TODO\n",
     "#Set the folder with saved neural network weights\n",
@@ -156,7 +169,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ace4213b",
    "metadata": {},
    "source": [
     "### Define the design in a numpy array"
@@ -165,7 +177,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b5a6b029",
    "metadata": {},
    "outputs": [
     {
@@ -202,7 +213,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4fe654ba",
    "metadata": {},
    "source": [
     "### Define obstacle coordinate\n",
@@ -212,7 +222,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "a6cecd7a",
    "metadata": {},
    "outputs": [
     {
@@ -259,7 +268,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "426f58f1",
    "metadata": {},
    "source": [
     "### Set the parameters and create a Structure_Builder object"
@@ -267,17 +275,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
-   "id": "7641c89d",
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "succeed to connect\n",
-      "succeed to connect\n",
-      "speed: 1200\n"
+     "ename": "NameError",
+     "evalue": "name 'win32com' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/mm/95xps4kj035cyly7yx9l_0p40000gn/T/ipykernel_35329/2232724553.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mscan_mV\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m500\u001b[0m \u001b[0;31m#bias voltage\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mspeed\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1200\u001b[0m \u001b[0;31m#scan speed (A/s)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 6\u001b[0;31m \u001b[0mcreatec_controller\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mCreatec_Controller\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      7\u001b[0m \u001b[0mx_nm\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my_nm\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcreatec_controller\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_offset_nm\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[0mlarge_offset_nm\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mx_nm\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my_nm\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;31m#Set offset to current offset value\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Desktop/Aalto Atomic Scale Physics/Atom_manipulation_with_RL_new/AMRL/Environment/createc_control.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, im_size_nm, offset_nm, pixel, scan_mV)\u001b[0m\n\u001b[1;32m     41\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mscan_mV\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     42\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mscan_mV\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mscan_mV\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 43\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstm\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mwin32com\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclient\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDispatch\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"pstmafm.stmafmrem\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     44\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstmready\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m==\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     45\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'succeed to connect'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'win32com' is not defined"
      ]
     }
    ],
@@ -310,7 +320,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7eed0a78",
    "metadata": {},
    "source": [
     "### Define folder name for saving data"
@@ -318,10 +327,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "21fa455e",
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The new directory is created!\n"
+     ]
+    }
+   ],
    "source": [
     "folder_name = 'C:/LocalUserData/User-data/phys-asp-lab/auto_manipulation/kagome_build_1/diamond_15'\n",
     "\n",
@@ -333,7 +349,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b496fc4e",
    "metadata": {},
    "source": [
     "### Set the parameters and start the building process"
@@ -341,12 +356,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e9b50680",
+   "execution_count": 15,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'env' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/mm/95xps4kj035cyly7yx9l_0p40000gn/T/ipykernel_35329/1241576793.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      7\u001b[0m \u001b[0manchor_position\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m201\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m80.7\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[0manchor_design\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m \u001b[0;36m2.2\u001b[0m\u001b[0;34m,\u001b[0m  \u001b[0;36m3.6\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 9\u001b[0;31m returns = env.reset_large(design_nm,\n\u001b[0m\u001b[1;32m     10\u001b[0m                   \u001b[0malign_design_mode\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'manual'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     11\u001b[0m                   \u001b[0malign_design_params\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m'atom_nm'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0manchor_position\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'design_nm'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0manchor_design\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'obstacle_nm'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0moutside_obstacles\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'env' is not defined"
+     ]
+    }
+   ],
    "source": [
     "#TODO\n",
     "#If align_design_mode = 'manual', one atom in the design is aligned with one atom in the STM image\n",
@@ -378,11 +404,18 @@
     "    if done:\n",
     "        break"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -396,7 +429,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/single_atom_training.ipynb
+++ b/single_atom_training.ipynb
@@ -27,11 +27,8 @@
     "import pandas as pd\n",
     "from collections import deque, namedtuple\n",
     "import torch\n",
-    "from Environment.Env_new import RealExpEnv\n",
-    "from RL.sac import sac_agent, ReplayMemory, HerReplayMemory\n",
-    "from Environment.data_visualization import plot_graph, show_reset, show_done, show_step\n",
-    "from Environment.episode_memory import Episode_Memory\n",
-    "from Environment.createc_control import Createc_Controller\n",
+    "from AMRL import RealExpEnv, Episode_Memory, Createc_Controller, sac_agent, ReplayMemory, HerReplayMemory\n",
+    "from AMRL import plot_graph, show_reset, show_done, show_step\n",
     "matplotlib.rcParams['image.cmap'] = 'gray'\n",
     "device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')\n",
     "print(device)"
@@ -47,40 +44,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "succeed to connect\n",
-      "(128, 128)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.image.AxesImage at 0x1d3086c50d0>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQ8AAAD8CAYAAABpXiE9AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAANn0lEQVR4nO3df6jd9X3H8edrGv9JHSamNmlMo4UwcYOu7pLaOSRjtWgQ0j+kxD+qyOBiUWih/UMq2L8G2/4oTC3NAhUVig601bCl66yUxf6hM8ZETbVr6gQvCU0Xs1jbosv23h/3a3e5PTf33s/53nNO0ucDDuf743O+77cf5ZXv+Z7v16SqkKTl+r1xNyDp7GR4SGpieEhqYnhIamJ4SGpieEhqcv4wH06yFvgH4DLgDeCzVXVywLg3gF8A/wOcrqqpYepKGr9hzzzuAp6uqi3A0936Qv68qv7Y4JDODcOGxw7goW75IeAzQx5P0lkiw9xhmuS/quqiOesnq2rNgHH/AZwECvj7qtp9hmNOA9MAq1ev/pMrrriiub9z3YkTJ8bdwsQ7fvz4uFuYaO+++y6nT59Oy2cXveaR5PvA+gG77l5GnWuq6miSS4CnkrxWVfsGDeyCZTfA1NRU7d+/fxllfrc8+OCD425h4t13333jbmGivfbaa82fXTQ8qupTC+1L8rMkG6rqWJINwMCYr6qj3fvxJN8BtgIDw0PS2WHYax57gFu75VuBJ+cPSLI6yYXvLwOfBl4Zsq6kMRs2PP4auC7JT4DrunWSfDjJ3m7Mh4AfJjkE/BvwT1X1z0PWlTRmQ93nUVUngL8YsP0osL1bfh342DB1JE0e7zCV1MTwkNTE8JDUxPCQ1MTwkNTE8JDUxPCQ1MTwkNTE8JDUxPCQ1MTwkNTE8JDUxPCQ1MTwkNTE8JDUxPCQ1MTwkNTE8JDUxPCQ1MTwkNTE8JDUxPCQ1MTwkNTE8JDUxPCQ1MTwkNTE8JDUpJfwSHJ9kh8nOZLkrgH7k+Tebv9LSa7qo66k8Rk6PJKcB3wduAG4Erg5yZXzht0AbOle08A3hq0rabz6OPPYChypqter6j3gUWDHvDE7gIdr1rPARUk29FBb0pj0ER4bgTfnrM9025Y7RtJZpI/wyIBt1TBmdmAynWR/kv0///nPh25O0sroIzxmgE1z1i8FjjaMAaCqdlfVVFVNffCDH+yhPUkroY/weB7YkuTyJBcAO4E988bsAW7pfnW5GjhVVcd6qC1pTM4f9gBVdTrJncD3gPOAB6rqcJLbu/27gL3AduAI8CvgtmHrShqvocMDoKr2MhsQc7ftmrNcwB191JI0GbzDVFITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1KTXsIjyfVJfpzkSJK7BuzfluRUkoPd654+6koan/OHPUCS84CvA9cBM8DzSfZU1Y/mDX2mqm4ctp6kydDHmcdW4EhVvV5V7wGPAjt6OK6kCTb0mQewEXhzzvoM8IkB4z6Z5BBwFPhyVR0edLAk08A0wPr163nxxRd7aPHc9Nhjj427hYl34MCBcbdwzurjzCMDttW89QPA5qr6GHAf8MRCB6uq3VU1VVVTa9as6aE9SSuhj/CYATbNWb+U2bOL36iqt6vqnW55L7Aqyboeaksakz7C43lgS5LLk1wA7AT2zB2QZH2SdMtbu7oneqgtaUyGvuZRVaeT3Al8DzgPeKCqDie5vdu/C7gJ+HyS08CvgZ1VNf+rjaSzSB8XTN//KrJ33rZdc5bvB+7vo5akyeAdppKaGB6SmhgekpoYHpKaGB6SmhgekpoYHpKaGB6SmhgekpoYHpKaGB6SmhgekpoYHpKaGB6SmhgekpoYHpKaGB6SmhgekpoYHpKaGB6SmhgekpoYHpKaGB6SmhgekpoYHpKaGB6Smhgekpr0Eh5JHkhyPMkrC+xPknuTHEnyUpKr+qgraXz6OvN4ELj+DPtvALZ0r2ngGz3VlTQmvYRHVe0D3jrDkB3AwzXrWeCiJBv6qC1pPEZ1zWMj8Oac9Zlu229JMp1kf5L9J0+eHElzkpZvVOGRAdtq0MCq2l1VU1U1tWbNmhVuS1KrUYXHDLBpzvqlwNER1Za0AkYVHnuAW7pfXa4GTlXVsRHVlrQCzu/jIEkeAbYB65LMAF8FVgFU1S5gL7AdOAL8Critj7qSxqeX8KiqmxfZX8AdfdSSNBm8w1RSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1ITw0NSE8NDUhPDQ1KTXsIjyQNJjid5ZYH925KcSnKwe93TR11J49PLX3QNPAjcDzx8hjHPVNWNPdWTNGa9nHlU1T7grT6OJens0NeZx1J8Mskh4Cjw5ao6PGhQkmlgGmDjxo1cfPHFI2zx7HLttdeOu4WJt2/fvnG3MNF++ctfNn92VBdMDwCbq+pjwH3AEwsNrKrdVTVVVVNr164dUXuSlmsk4VFVb1fVO93yXmBVknWjqC1pZYwkPJKsT5JueWtX98QoaktaGb1c80jyCLANWJdkBvgqsAqgqnYBNwGfT3Ia+DWws6qqj9qSxqOX8KiqmxfZfz+zP+VKOkd4h6mkJoaHpCaGh6QmhoekJoaHpCaGh6QmhoekJoaHpCaGh6QmhoekJoaHpCaGh6QmhoekJoaHpCaGh6QmhoekJoaHpCaGh6QmhoekJoaHpCaGh6QmhoekJoaHpCaGh6QmhoekJoaHpCaGh6QmQ4dHkk1JfpDk1SSHk3xhwJgkuTfJkSQvJblq2LqSxquPv+j6NPClqjqQ5ELghSRPVdWP5oy5AdjSvT4BfKN7l3SWGvrMo6qOVdWBbvkXwKvAxnnDdgAP16xngYuSbBi2tqTx6fWaR5LLgI8Dz83btRF4c876DL8dMJLOIr2FR5IPAI8DX6yqt+fvHvCRWuA400n2J9n/1ltv9dWepJ71Eh5JVjEbHN+qqm8PGDIDbJqzfilwdNCxqmp3VU1V1dTatWv7aE/SCujj15YA3wReraqvLTBsD3BL96vL1cCpqjo2bG1J49PHry3XAJ8DXk5ysNv2FeAjAFW1C9gLbAeOAL8CbuuhrqQxGjo8quqHDL6mMXdMAXcMW0vS5PAOU0lNDA9JTQwPSU0MD0lNDA9JTQwPSU0MD0lNDA9JTQwPSU0MD0lNDA9JTQwPSU0MD0lNDA9JTQwPSU0MD0lNDA9JTQwPSU0MD0lNDA9JTQwPSU0MD0lNDA9JTQwPSU0MD0lNDA9JTQwPSU0MD0lNhg6PJJuS/CDJq0kOJ/nCgDHbkpxKcrB73TNsXUnjdX4PxzgNfKmqDiS5EHghyVNV9aN5456pqht7qCdpAgx95lFVx6rqQLf8C+BVYOOwx5U02fo48/iNJJcBHweeG7D7k0kOAUeBL1fV4QWOMQ1Md6vvbt68+ZU+exzSOuA/x93EHPazuEnradL6+YPWD6aqeukgyQeAfwX+qqq+PW/f7wP/W1XvJNkO/F1VbVnCMfdX1VQvDfbAfs5s0vqByevpXOqnl19bkqwCHge+NT84AKrq7ap6p1veC6xKsq6P2pLGo49fWwJ8E3i1qr62wJj13TiSbO3qnhi2tqTx6eOaxzXA54CXkxzstn0F+AhAVe0CbgI+n+Q08GtgZy3t+9LuHvrrk/2c2aT1A5PX0znTT2/XPCT9bvEOU0lNDA9JTSYmPJKsTfJUkp9072sWGPdGkpe729z3r0Af1yf5cZIjSe4asD9J7u32v5Tkqr57aOhpZLf/J3kgyfEkA++/GdP8LNbTSB+PWOIjGyObpxV7hKSqJuIF/C1wV7d8F/A3C4x7A1i3Qj2cB/wU+ChwAXAIuHLemO3Ad4EAVwPPrfC8LKWnbcA/jujf07XAVcArC+wf6fwssaeRzU9XbwNwVbd8IfDv4/zvaIn9LHuOJubMA9gBPNQtPwR8Zgw9bAWOVNXrVfUe8GjX11w7gIdr1rPARUk2jLmnkamqfcBbZxgy6vlZSk8jVUt7ZGNk87TEfpZtksLjQ1V1DGb/YYFLFhhXwL8keaG7lb1PG4E356zP8NuTvJQxo+4Jutv/k3w3yR+uYD+LGfX8LNVY5ucMj2yMZZ6W8gjJUueo12dbFpPk+8D6AbvuXsZhrqmqo0kuAZ5K8lr3J08fMmDb/N+ylzKmT0updwDYXP9/+/8TwKK3/6+QUc/PUoxlfrpHNh4HvlhVb8/fPeAjKzpPi/Sz7Dka6ZlHVX2qqv5owOtJ4Gfvn7Z178cXOMbR7v048B1mT+v7MgNsmrN+KbMP8i13TJ8WrVeTdfv/qOdnUeOYn8Ue2WDE87QSj5BM0teWPcCt3fKtwJPzByRZndn/ZwhJVgOfBvp86vZ5YEuSy5NcAOzs+prf5y3d1fKrgVPvf91aIYv2lMm6/X/U87OoUc9PV+uMj2wwwnlaSj9Nc7SSV52XeUX4YuBp4Cfd+9pu+4eBvd3yR5n9teEQcBi4ewX62M7s1eifvn984Hbg9m45wNe7/S8DUyOYm8V6urObj0PAs8CfrmAvjwDHgP9m9k/Pv5yA+Vmsp5HNT1fvz5j9CvIScLB7bR/XPC2xn2XPkbenS2oySV9bJJ1FDA9JTQwPSU0MD0lNDA9JTQwPSU0MD0lN/g+1Rgiwim7unwAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "createc_controller = Createc_Controller(None, None, None, None)\n",
     "img_forward = np.array(createc_controller.stm.scandata(1,4))\n",
@@ -101,18 +67,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "succeed to connect\n",
-      "Load cnn weight\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#TODO\n",
     "step_nm = 0.4 #Set the radius of the manipulation start position relative the the atom start position\n",
@@ -156,18 +113,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13268837332725525\n",
-      "tensor([0.1327], device='cuda:0')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#TODO\n",
     "batch_size= 64 #Set minibatch size\n",
@@ -212,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +316,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -382,7 +330,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Simplified import statements now work on the baseline_eval.ipynb, multiple_atoms_building.ipynb, single_atom_training.ipynb Jupyter notebooks from my Macbook (unable to test win32com.client but should work). Still need to update imports in the notebooks/ folder for them to work with the new structure.